### PR TITLE
Tweak description

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -36,7 +36,7 @@
 		<meta property="term" refines="#subject-1">Unknown</meta>
 		<meta property="se:subject">Adventure</meta>
 		<meta property="se:subject">Fiction</meta>
-		<dc:description id="description">A colorful Victorian-era tale of a race to cirumnavigate the globe.</dc:description>
+		<dc:description id="description">On a bet, an eccentric Victorian gentleman races to circumnavigate the globe.</dc:description>
 		<meta id="long-description" property="se:long-description" refines="#description">
 			&lt;p&gt;&lt;a href="https://standardebooks.org/ebooks/jules-verne"&gt;Jules Verne’s&lt;/a&gt; most-acclaimed novel remains a cultural cornerstone to this day. The story of Phileas Fogg’s spectacular journey by then-novel technologies is a fast-paced, colorful, and thoroughly enjoyable portrait of the British empire at the height of its power.&lt;/p&gt;
 			&lt;p&gt;Originally published as a serial so believable that readers at the time placed bets on whether Fogg would succeed or not, Verne’s adventure epic continues to inspire travelers and adventurers to this day.&lt;/p&gt;


### PR DESCRIPTION
- “cirumnavigate” is a typo
- complete sentence